### PR TITLE
Update composer requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "blade-ui-kit/blade-icons": "^1.1.1",
-        "illuminate/contracts": "^8.0"
+        "blade-ui-kit/blade-icons": "^1.1",
+        "illuminate/contracts": "^8.0|^9.0"
     },
     "require-dev": {
         "orchestra/testbench": "^6.0",


### PR DESCRIPTION
This changes the composer requirements to match those in: https://github.com/blade-ui-kit/blade-icons-template/blob/main/composer.json

It fixes an error I get on the current main branch, when I run this command in my laravel (^9.11) project:
```bash
$ composer require ublabs/blade-simple-icons:*
[...]
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - ublabs/blade-simple-icons[dev-feature/update-icons, dev-main, 0.1.0, ..., 0.37.0] require illuminate/contracts ^8.0 -> found illuminate/contracts[v8.0.0, ..., 8.x-dev] but these were not loaded, likely because it conflicts with another require.
    - Root composer.json requires ublabs/blade-simple-icons * -> satisfiable by ublabs/blade-simple-icons[dev-feature/update-icons, dev-main, 0.1.0, ..., 0.37.0].


Installation failed, reverting ./composer.json and ./composer.lock to their original content. 
```